### PR TITLE
dynamically add calendar object to parent scope #10

### DIFF
--- a/demo/calendarDemo.js
+++ b/demo/calendarDemo.js
@@ -4,6 +4,7 @@
 angular.module('calendarDemoApp', ['ui.calendar']);
 
 function CalendarCtrl($scope) {
+    $scope.myCalendar = '';
     var date = new Date();
     var d = date.getDate();
     var m = date.getMonth();
@@ -32,7 +33,7 @@ function CalendarCtrl($scope) {
       callback(events);
     };
     /* alert on eventClick */
-    $scope.addEventOnClick = function( date, allDay, jsEvent, view ){
+    $scope.alertEventOnClick = function( date, allDay, jsEvent, view ){
         $scope.$apply(function(){
           $scope.alertMessage = ('Day Clicked ' + date);
         });
@@ -74,6 +75,10 @@ function CalendarCtrl($scope) {
     /* remove event */
     $scope.remove = function(index) {
       $scope.events.splice(index,1);
+    };
+    /* Change View */
+    $scope.changeView = function(view) {
+      $scope.myCalendar.fullCalendar('changeView',view);
     };
     /* config object */
     $scope.uiConfig = {

--- a/demo/index.html
+++ b/demo/index.html
@@ -77,12 +77,14 @@
                     <div class="span8">
                         <div class="alert-success calAlert"><h4>{{alertMessage}}</h4></div>
                         <div class="btn-toolbar">
-                            <p class="pull-right lead">You can drag events below</p>
                             <div class="btn-group">
                                 <button class="btn btn-info" ng-click="addRemoveEventSource(eventSources,eventSource)">Toggle an event source</button>
+                                <button class="btn btn-success" ng-click="changeView('agendaDay')">AgendaDay</button>
+                                <button class="btn btn-success" ng-click="changeView('agendaWeek')">AgendaWeek</button>
+                                <button class="btn btn-success" ng-click="changeView('month')">Month</button>
                             </div>
                         </div>
-                        <div class="calendar" ng-model="eventSources" ui-calendar="uiConfig.calendar"></div>
+                        <div class="calendar" ng-model="eventSources" ui-calendar="uiConfig.calendar" calendar="myCalendar"></div>
                     </div>
                 </div>
             </div>
@@ -93,6 +95,7 @@
 angular.module('calendarDemoApp', ['ui.calendar']);
 
 function CalendarCtrl($scope) {
+    $scope.myCalendar = '';
     var date = new Date();
     var d = date.getDate();
     var m = date.getMonth();
@@ -121,7 +124,7 @@ function CalendarCtrl($scope) {
       callback(events);
     };
     /* alert on eventClick */
-    $scope.addEventOnClick = function( date, allDay, jsEvent, view ){
+    $scope.alertEventOnClick = function( date, allDay, jsEvent, view ){
         $scope.$apply(function(){
           $scope.alertMessage = ('Day Clicked ' + date);
         });
@@ -164,6 +167,10 @@ function CalendarCtrl($scope) {
     $scope.remove = function(index) {
       $scope.events.splice(index,1);
     };
+    /* Change View */
+    $scope.changeView = function(view) {
+      $scope.myCalendar.fullCalendar('changeView',view);
+    };
     /* config object */
     $scope.uiConfig = {
       calendar:{
@@ -181,6 +188,7 @@ function CalendarCtrl($scope) {
     };
     /* event sources array*/
     $scope.eventSources = [$scope.events, $scope.eventSource, $scope.eventsF];
+}
 }
 </pre>
         </section>

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -17,9 +17,15 @@ angular.module('ui.calendar', [])
     require: 'ngModel',
     scope: true,
     restrict: 'A',
-    link: function(scope, elm, attrs) {
+    link: function(scope, elm, attrs, parent) {
       var sources = scope.$eval(attrs.ngModel);
-      var calendar = elm.html('');
+      var calendar;
+      if(!attrs.calendar){
+        calendar = elm.html(''); 
+      }
+      else{
+        calendar = angular.element(elm.parent()).scope()[attrs.calendar] = elm.html('');
+      }
       var eventsFingerprint = function() {
         var fpn = "";
         angular.forEach(sources, function(events) {

--- a/test/calendar.spec.js
+++ b/test/calendar.spec.js
@@ -29,7 +29,7 @@ describe('uiCalendar', function () {
             {title: 'Long Event 2',start: new Date(y, m, d - 5),end: new Date(y, m, d - 2)},
             {id: 998,title: 'Repeating Event 2',start: new Date(y, m, d - 3, 16, 0),allDay: false},
             {id: 998,title: 'Repeating Event 2',start: new Date(y, m, d + 4, 16, 0),allDay: true}];
-          //array to test equalsTracker with
+          //array to test equals case with
           scope.events3 = [
             {title: 'All Day Event 3',start: new Date(y, m, 1),url: 'http://www.atlantacarlocksmith.com'},
             {title: 'Long Event 3',start: new Date(y, m, d - 5),end: new Date(y, m, d - 2)},
@@ -38,11 +38,6 @@ describe('uiCalendar', function () {
 
           // create an array of events, to pass into the directive. 
           scope.events4 = [{title: 'All Day Event 3',start: new Date(y, m, 1),url: 'http://www.yoyoyo.com'}];
-
-          //equalsTracker to force the calendar to update on rare occasions
-          //ie... an event source is replacing another and has the same length as the prior eventSource
-          //or... replacing an eventSource that is an object with another eventSource
-          scope.equalsTracker = 0;
 
           //event Sources array  
           scope.eventSources = [scope.events,scope.events2]; //End of Events Array
@@ -186,7 +181,7 @@ describe('uiCalendar', function () {
         /* Test to see if calendar is updating when an eventSource replaces another with an equal length. */
         it('should update the calendar if an eventSource has same length as prior eventSource', function () {
             spyOn($.fn, 'fullCalendar');
-            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources" equals-tracker="equalsTracker"></div>')(scope);
+            $compile('<div ui-calendar="uiConfig.calendar" ng-model="eventSources"></div>')(scope);
             var clientEventSources = $.fn.fullCalendar.mostRecentCall.args[0].eventSources;
             var clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
             expect(clientEventsLength).toEqual(4);
@@ -194,9 +189,6 @@ describe('uiCalendar', function () {
             expect(clientEventSources[1][0].title).toEqual('All Day Event 2');
             //replace source with one that has the same length
             scope.eventSources.splice(1,1,scope.events3);
-            //must update the equalsTracker as we would detect that the length is equal from controller
-            scope.equalsTracker++;
-            //eventSources should update inside the calendar since we incremented the equalsTracker 
             clientEventSources = $.fn.fullCalendar.mostRecentCall.args[0].eventSources;
             expect(clientEventSources.length).toEqual(2);
             expect(clientEventSources[1][0].title).toEqual('All Day Event 3');
@@ -205,7 +197,7 @@ describe('uiCalendar', function () {
             clientEventsLength = $.fn.fullCalendar.mostRecentCall.args[0].eventSources[0].length;
             expect(clientEventsLength).toEqual(3);
            
-        });
+        });      
 
        });
 


### PR DESCRIPTION
Adds a dynamic calendar object to the parent scope. This allows the user to create multiple calendars on the same scope with different names and not have them clash with each other. 

The calendar is still using a child scope so that the functions can be passed in correctly.
