### PR TITLE
(feat) custom eventRender support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,14 @@ You can use fullcalendar's `eventRender` option to customize how events are rend
 However, only certain event attributes are watched for changes (they are `id`, `title`, `url`, `start`, `end`, `allDay`, and `className`).
 
 If you need to automatically re-render other event data, you can use `calendar-watch-event`.
-`calendar-watch-event` expression is evaluated with an `event` local variable and should return a string or a number, for example:
+`calendar-watch-event` expression must return a function that is passed `event` as argument and returns a string or a number, for example:
 
-    <ui-calendar calendar-watch-event="event.price" ... >
-    <ui-calendar calendar-watch-event="someScopeMethod(event)" ... >
+    $scope.extraEventSignature = function(event) {
+       returns "" + event.price;
+    }
+
+    <ui-calendar calendar-watch-event="extraEventSignature" ... >
+    // will now watch for price
 
 ## Documentation for the Calendar
 

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -44,13 +44,16 @@ angular.module('ui.calendar', [])
       //  tokenFn function(object) that returns the token for a given object
       var changeWatcher = function(arraySource, tokenFn) {
         var self;
-        var getTokens = function() {
+        var getTokens = function changeWatcherGetTokens() {
           var array = angular.isFunction(arraySource) ? arraySource() : arraySource;
-          return array.map(function(el) {
-            var token = tokenFn(el);
+          var result = [], token, el;
+          for (var i = 0, n = array.length; i < n; i++) {
+            el = array[i];
+            token = tokenFn(el);
             map[token] = el;
-            return token;
-          });
+            result.push(token);
+          }
+          return result;
         };
         // returns elements in that are in a but not in b
         // subtractAsSets([4, 5, 6], [4, 5, 7]) => [6]
@@ -140,13 +143,14 @@ angular.module('ui.calendar', [])
         }
         return Array.prototype.concat.apply([], arraySources);
       };
-      var eventsWatcher = changeWatcher(allEvents, function(e) {
+      var extraEventSignature = scope.calendarWatchEvent() || angular.noop;
+      var eventsWatcher = changeWatcher(allEvents, function calendarWatchEvent(e) {
         if (!e.__uiCalId) {
           e.__uiCalId = eventSerialId++;
         }
         // This extracts all the information we need from the event. http://jsperf.com/angular-calendar-events-fingerprint/3
         return "" + e.__uiCalId + (e.id || '') + (e.title || '') + (e.url || '') + (+e.start || '') + (+e.end || '') +
-            (e.allDay || '') + (e.className || '') + scope.calendarWatchEvent({event: e}) || '';
+          (e.allDay || '') + (e.className || '') + extraEventSignature(e) || '';
       });
       eventsWatcher.subscribe(scope, function(newTokens, oldTokens) {
         if (sourcesChanged) {


### PR DESCRIPTION
You can use fullcalendar's `eventRender` option to customize how events are rendered in the calendar.
However, only certain event properties are watched for changes (they are `id`, `title`, `url`, `start`, `end`, `allDay`, and `className`).

If you need to re-render other event data automatically, with this PR you can use `calendar-watch-event`.
`calendar-watch-event` expression is evaluated with an `event` and should return a string or a number, for example:

```
<ui-calendar calendar-watch-event="event.price" ... >
<ui-calendar calendar-watch-event="someScopeMethod(event)" ... >
```
