### PR TITLE
Fixed formatting under "Testing" heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ A complete AngularJS directive for the Arshaw FullCalendar.
 
 We use testacular and jshint to ensure the quality of the code.  The easiest way to run these checks is to use grunt:
 
-  npm install -g grunt-cli
-  npm install
-  bower install
-  grunt
+    npm install -g grunt-cli
+    npm install
+    bower install
+    grunt
 
 # Usage
 


### PR DESCRIPTION
The console instructions under "Testing" weren't rendering as code. Added an extra tab so it would be recognized as a code block
