### PR TITLE
Fixed variable in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ All the Arshaw Fullcalendar options can be passed through the directive. This ev
         };
     });
 
-    <div ui-calendar="calendarOptions" ng-model="eventSources">
+    <div ui-calendar="uiConfig.calendar" ng-model="eventSources">
 
 ## Working with ng-model
 


### PR DESCRIPTION
The example created one object, but in the next line it referred to a different configuration object.

``` js
myAppModule.controller('MyController', function($scope) {
    /* config object */
    $scope.uiConfig = {
      calendar:{
...
      }
    };
});

<div ui-calendar="calendarOptions" ng-model="eventSources">
```

to

``` js
<div ui-calendar="uiConfig.calendar" ng-model="eventSources">
```
