### PR TITLE
fix paths for current bower, jquery-ui, and ui-calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ To your `components.json` file. Then run
 
 This will copy the ui-calendar files into your `components` folder, along with its dependencies. Load the script files in your application:
 
-    <script type="text/javascript" src="components/jquery/jquery.js"></script>
-    <script type="text/javascript" src="components/jquery-ui\ui\jquery-ui.custom.js"></script>
-    <script type="text/javascript" src="components/angular/angular.js"></script>
-    <script type="text/javascript" src="components/angular-ui-calendar/calendar.js"></script>
+    <script type="text/javascript" src="bower_components/jquery/jquery.js"></script>
+    <script type="text/javascript" src="bower_components/jquery-ui/ui/jquery-ui.js"></script>
+    <script type="text/javascript" src="bower_components/angular/angular.js"></script>
+    <script type="text/javascript" src="bower_components/angular-ui-calendar/src/calendar.js"></script>
 
 Add the calendar module as a dependency to your application module:
 


### PR DESCRIPTION
I found the paths did not agree with my current install, this updates them to be correct.
