### PR TITLE
Fixed broken links on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 A complete AngularJS directive for the Arshaw FullCalendar.
 
 # Requirements
-- ([fullcalendar.css](https://raw.github.com/angular-ui/angular-ui.github.com/master/lib/calendar/fullcalendar.css))
-- ([JQuery](http://arshaw.com/js/fullcalendar-1.5.3/fullcalendar/gcal.js))
+- ([fullcalendar.css](https://raw.github.com/angular-ui/angular-ui.github.com/4e6ff34ca50a15da77ef8fe9781c38307ed81637/lib/calendar/fullcalendar.css))
+- ([JQuery](http://code.jquery.com/jquery-1.10.2.min.js))
 - ([JQueryUI](http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js))
 - ([AngularJS](http://code.angularjs.org/1.0.4/angular.js))
-- ([fullcalendar.js](https://raw.github.com/angular-ui/angular-ui.github.com/master/lib/calendar/fullcalendar.js))
+- ([fullcalendar.js](https://raw.github.com/angular-ui/angular-ui.github.com/4e6ff34ca50a15da77ef8fe9781c38307ed81637/lib/calendar/fullcalendar.js))
 - optional - ([gcal-plugin](http://arshaw.com/js/fullcalendar-1.5.3/fullcalendar/gcal.js))
 
 # Testing


### PR DESCRIPTION
Fixed the following broken links on the README file: 
- fullcalendar.css
- fullcalendar.js
- jQuery
