### PR TITLE
fix(calendar.js): do not alter original execution context #107 #87 #105

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -26,8 +26,9 @@ angular.module('ui.calendar', [])
                       // In this way the function will be safely executed on the next digest.
 
                       var args = arguments;
+                      var _this = this;
                       $timeout(function(){
-                          functionToWrap.apply(this, args);
+                        functionToWrap.apply(_this, args);
                       });
                   };
               }

--- a/test/calendar.spec.js
+++ b/test/calendar.spec.js
@@ -375,9 +375,7 @@ describe('uiCalendar', function () {
               var fullCalendarConfig = calendarCtrl.getFullCalendarConfig(scope.uiConfig.calendar, {});
 
               fullCalendarConfig[key]();
-
               $timeout.flush();
-
               expect($rootScope.$apply.callCount).toBe(functionCount);
               expect(scope.uiConfig.calendar[key]).toHaveBeenCalled();
               $rootScope.$apply.isSpy = false;
@@ -414,7 +412,6 @@ describe('uiCalendar', function () {
               
               scope.$apply();
               $timeout.flush();
-
               expect($rootScope.$apply.callCount).toBe(functionCount*2);
               expect(scope.uiConfig.calendar[key]).toHaveBeenCalled();
             }


### PR DESCRIPTION
Make sure that when we are adding an apply to all function calls that we do not take away the original execution context. 
