### PR TITLE
prevent appending 'undefined' to unique tokens

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -41,7 +41,7 @@ angular.module('ui.calendar', [])
         }
         // This extracts all the information we need from the event. http://jsperf.com/angular-calendar-events-fingerprint/3
         return "" + e.__uiCalId + (e.id || '') + (e.title || '') + (e.url || '') + (+e.start || '') + (+e.end || '') +
-          (e.allDay || '') + (e.className || '') + extraEventSignature(e) || '';
+          (e.allDay || '') + (e.className || '') + (extraEventSignature(e) || '');
       };
 
       this.sourcesFingerprint = function(source) {


### PR DESCRIPTION
It's a minor thing, but while debugging I was getting unique tokens like "11400767418683undefined" :)
