### PR TITLE
fix(calendarWatchEvent) extracting real function from angular parentGet

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -15,7 +15,7 @@ angular.module('ui.calendar', [])
       var sourceSerialId = 1,
           eventSerialId = 1,
           sources = $scope.eventSources,
-          extraEventSignature = $scope.calendarWatchEvent ? $scope.calendarWatchEvent : angular.noop,
+          extraEventSignature = $scope.calendarWatchEvent() ? $scope.calendarWatchEvent() : angular.noop,
 
           wrapFunctionWithScopeApply = function(functionToWrap){
               var wrapper;

--- a/test/calendar.spec.js
+++ b/test/calendar.spec.js
@@ -201,6 +201,7 @@ describe('uiCalendar', function () {
         }
 
         beforeEach(function(){
+          scope.calendarWatchEvent = angular.noop;
           calendarCtrl = $controller('uiCalendarCtrl', {$scope: scope, $element: null});
           sourcesChanged = false;
           scope.$apply();
@@ -247,8 +248,8 @@ describe('uiCalendar', function () {
         it('should make sure the correct function is called when the calendarWatchEvent function is return variable is altered', function () {
           scope.testX = 0;
 
-          scope.calendarWatchEvent = function(){
-            return scope.testX;
+          scope.calendarWatchEvent = function() { 
+            return function(){ return scope.testX; };
           };
 
           var calendarCtrl2 = $controller('uiCalendarCtrl', {$scope: scope, $element: null});
@@ -346,6 +347,7 @@ describe('uiCalendar', function () {
         var calendarCtrl;
 
         beforeEach(function(){
+          scope.calendarWatchEvent = angular.noop;
           calendarCtrl = $controller('uiCalendarCtrl', {$scope: scope, $element: null});
           scope.$apply();
         });


### PR DESCRIPTION
Hey,

There was a problem related with calendarWatchEvent. Because of using '&' binding, result of extraEventSignature(e) was the function defined in parent scope (extraEventSignature(e) called angular parentGet function). In result eventFingerprint contained definition of function related with calendarWatchEvents (casted to string) instead of true result of it.

I think I have fixed it in this PR. I hope it will be usefull. I would be glad if anyone could check this.
Thanks in advance.  Best regards.