### PR TITLE
Don't wrap callback functions which need to return value to fullcalendar...

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -156,9 +156,9 @@ angular.module('ui.calendar', [])
 
           angular.extend(config, uiCalendarConfig);
           angular.extend(config, calendarSettings);
-         
+ 
           angular.forEach(config, function(value,key){
-            if (typeof value === 'function'){
+            if (typeof value === 'function' && ['eventDataTransform', 'eventClick'].indexOf(key) === -1){
               config[key] = wrapFunctionWithScopeApply(config[key]);
             }
           });


### PR DESCRIPTION
According to http://arshaw.com/fullcalendar/docs1/mouse/eventClick/ and http://arshaw.com/fullcalendar/docs1/event_data/eventDataTransform/ , after fullcalendar calls `eventClick` and `eventDataTransform`, it will then consume the return value.

If we wrap those two callbacks with `wrapFunctionWithScopeApply`, the wrapper function calls the wrapped function with `$timeout` and never pass the return value back to fullcalendar.

This breaks the design of these callbacks.

To fix this issue, the patch just avoid to wrap `eventClick` and `eventDataTransform`. I just did a quick scan of the documents and only find these two. There might be more callbacks to ignore.

This PR fixed #122
