### PR TITLE
Fix lang parameter being overriden by $locale. Fix #135

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -208,11 +208,11 @@ angular.module('ui.calendar', [])
 
           fullCalendarConfig = controller.getFullCalendarConfig(calendarSettings, uiCalendarConfig);
 
-          var localeConfig = controller.getLocaleConfig(fullCalendarConfig);
-          angular.extend(fullCalendarConfig, localeConfig);
+          var localeFullCalendarConfig = controller.getLocaleConfig(fullCalendarConfig);
+          angular.extend(localeFullCalendarConfig, fullCalendarConfig);
 
           options = { eventSources: sources };
-          angular.extend(options, fullCalendarConfig);
+          angular.extend(options, localeFullCalendarConfig);
 
           var options2 = {};
           for(var o in options){


### PR DESCRIPTION
This is the fix for lang support #135. 

Please note that i have added an option useNgLocale to keep the previous behavior even if lang property is defined, as it may have sense for people setting $locale in their angular app.
