### PR TITLE
Inject jQuery in a controllable way

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -8,6 +8,14 @@
 *
 */
 
+(function(factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['jquery'], factory);
+    } else {
+        factory(jQuery);
+    }
+})(function($) {
+
 angular.module('ui.calendar', [])
   .constant('uiCalendarConfig', {calendars: {}})
   .controller('uiCalendarCtrl', ['$scope', 
@@ -287,3 +295,5 @@ angular.module('ui.calendar', [])
       }
     };
 }]);
+
+});


### PR DESCRIPTION
This way it's possible to override jquery version used by ui-calendar if there are more than one on the page.