### PR TITLE
Make calendar instance accessible via uiCalendarConfig

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -243,6 +243,9 @@ angular.module('ui.calendar', [])
 
         scope.init = function(){
           calendar.fullCalendar(options);
+          if(attrs.calendar) {
+            uiCalendarConfig.calendars[attrs.calendar] = calendar;
+          }          
         };
 
         eventSourcesWatcher.onAdded = function(source) {


### PR DESCRIPTION
Update init() to add the calendar instance to uiCalendarConfig if attrs.calendar is specified