### PR TITLE
Escludes eventRender from function wrapper

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -164,7 +164,8 @@ angular.module('ui.calendar', [])
          
           angular.forEach(config, function(value,key){
             if (typeof value === 'function'){
-              config[key] = wrapFunctionWithScopeApply(config[key]);
+              if(key !== "eventRender")
+                config[key] = wrapFunctionWithScopeApply(config[key]);
             }
           });
 


### PR DESCRIPTION
Simple check on the name of the function wrapped in the timeout. This was preventing eventRender function to work properly with return value