### PR TITLE
Prevent events from disappearing with optional sticky events

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -256,7 +256,7 @@ angular.module('ui.calendar', [])
         };
 
         eventsWatcher.onAdded = function(event) {
-          calendar.fullCalendar('renderEvent', event);
+          calendar.fullCalendar('renderEvent', event, (event.stick ? true : false));
         };
 
         eventsWatcher.onRemoved = function(event) {


### PR DESCRIPTION
Simple, non-intrusive, fix for the common disappearing events problem (here #234 & #163 & #99 & #51). It simply allows the events to become sticky (3rd argument on renderEvent) if a property `event.stick` is set to true. This means that events will persistent across view changes.