### PR TITLE
Fixed onChanged for events

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -289,9 +289,12 @@ angular.module('ui.calendar', [])
         };
 
         eventsWatcher.onChanged = function(event) {
-          event._start = jQuery.fullCalendar.moment(event.start);
-          event._end = jQuery.fullCalendar.moment(event.end);
-          calendar.fullCalendar('updateEvent', event);
+          var clientEvents = calendar.fullCalendar('clientEvents', event._id);
+          for (var i = 0; i < clientEvents.length; i++) {
+            var clientEvent = clientEvents[i];
+            clientEvent = angular.extend(clientEvent, event);
+            calendar.fullCalendar('updateEvent', clientEvent);
+          }
         };
 
         eventSourcesWatcher.subscribe(scope);

--- a/test/calendar.spec.js
+++ b/test/calendar.spec.js
@@ -172,12 +172,20 @@ describe('uiCalendar', function () {
         });
 
         it('should make sure that if we just change the title of the event that it updates itself', function () {
+            var originalEvent = angular.copy(scope.events[0]);
+            $.fn.fullCalendar.andCallFake(function(method) {
+              if (method === 'clientEvents') {
+                return [ originalEvent ];
+              }
+            });
             scope.events[0].title = 'change title';
             scope.$apply();
             var fullCalendarParam = $.fn.fullCalendar.mostRecentCall.args[0];
             var fullCalendarParam1  = $.fn.fullCalendar.mostRecentCall.args[1];
             expect(fullCalendarParam).toEqual('updateEvent');
-            expect(fullCalendarParam1).toEqual(scope.events[0]);
+            expect(fullCalendarParam1).toEqual(originalEvent);
+            // fullCalendar 'updateEvent' need an original Event Object
+            expect(fullCalendarParam1).toBe(originalEvent);
         });
 
         it('should make sure that if the calendars options change then the fullcalendar method is called with the new options', function () {


### PR DESCRIPTION
*rebase of #189*

Based on documentation (http://fullcalendar.io/docs/event_data/updateEvent/)

> event must be the original Event Object for an event, not merely a reconstructed object. The original Event Object can obtained by callbacks such as eventClick, or by the clientEvents method.

I changed ```eventsWatcher.onChanged``` to work with original Event Object obtained by ```clientEvents``` method based on ```_id```

This should fix #186