### PR TITLE
fix(cal): Check for the correct `moment` location before use it.

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -284,8 +284,12 @@ angular.module('ui.calendar', [])
         };
 
         eventsWatcher.onChanged = function(event) {
-          event._start = jQuery.fullCalendar.moment(event.start);
-          event._end = jQuery.fullCalendar.moment(event.end);
+          var momentjs = (jQuery.fullCalendar && jQuery.fullCalendar.moment)
+            ? jQuery.fullCalendar.moment
+            : moment;
+
+          event._start = momentjs(event.start);
+          event._end = momentjs(event.end);
           calendar.fullCalendar('updateEvent', event);
         };
 

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -284,9 +284,7 @@ angular.module('ui.calendar', [])
         };
 
         eventsWatcher.onChanged = function(event) {
-          var momentjs = (jQuery.fullCalendar && jQuery.fullCalendar.moment)
-            ? jQuery.fullCalendar.moment
-            : moment;
+          var momentjs = (jQuery.fullCalendar && jQuery.fullCalendar.moment)? jQuery.fullCalendar.moment : moment;
 
           event._start = momentjs(event.start);
           event._end = momentjs(event.end);


### PR DESCRIPTION
As title says, before use the fullCalendar `moment` alias it would be good to check for its existence, since on old fullCalendar versions it is not defined, so the directive throws an error when the line is reached.

This kind of support is nice to have it since lot of themes out there have older implementations of fullCalendar that needs to be used instead the latest for the CSS/behavior theme compatibility.

Hoping you agree with me and accept the PR, and bump a new version soon :)