### PR TITLE
FIX: calendar-watch-event " & " directive binding needs a function ca…

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you need to automatically re-render other event data, you can use `calendar-w
        returns "" + event.price;
     }
 
-    <ui-calendar calendar-watch-event="extraEventSignature" ... >
+    <ui-calendar calendar-watch-event="extraEventSignature(event)" ... >
     // will now watch for price
 
 ### Adding new events issue

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -42,7 +42,7 @@ angular.module('ui.calendar', [])
         }
         // This extracts all the information we need from the event. http://jsperf.com/angular-calendar-events-fingerprint/3
         return "" + e._id + (e.id || '') + (e.title || '') + (e.url || '') + (+e.start || '') + (+e.end || '') +
-          (e.allDay || '') + (e.className || '') + extraEventSignature(e) || '';
+          (e.allDay || '') + (e.className || '') + extraEventSignature({event: e}) || '';
       };
 
       var sourceSerialId = 1, sourceEventsSerialId = 1;


### PR DESCRIPTION
FIX: calendar-watch-event " & " directive binding needs a function call in the markup and a map of argument when its called in JS

See angular doc for directives: https://docs.angularjs.org/guide/directive and the plunkr of the example with the close-dialog which illustrates '& binding': http://plnkr.co/edit/wdDvC9GSXgsW0nA5UdbR?p=preview

Any help for creating a test to avoid further regression would be much appreciated.
While all tests pass, they do not actually test the binding and the creation of the calendarWatchEvent function on the directive scope. They only test that if a calendarWatchEvent function is correctly defined, it will be called.