### PR TITLE
Fix eventFingerPrint when start/end are strings

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -40,9 +40,13 @@ angular.module('ui.calendar', [])
         if (!e._id) {
           e._id = eventSerialId++;
         }
+        var extraSignature = (extraEventSignature({event: e}) || '');
+        var start = moment.isMoment(e.start) ? e.start.unix() : (e.start ? moment(e.start).unix() : '');
+        var end =   moment.isMoment(e.end)   ? e.end.unix()   : (e.end   ? moment(e.end).unix()     : '');
+
         // This extracts all the information we need from the event. http://jsperf.com/angular-calendar-events-fingerprint/3
-        return "" + e._id + (e.id || '') + (e.title || '') + (e.url || '') + (+e.start || '') + (+e.end || '') +
-          (e.allDay || '') + (e.className || '') + extraEventSignature(e) || '';
+        return "" + e._id + (e.id || '') + (e.title || '') + (e.url || '') + start + end +
+          (e.allDay || '') + (e.className || '') + extraSignature;
       };
 
       var sourceSerialId = 1, sourceEventsSerialId = 1;


### PR DESCRIPTION
When event.start is a string (ISO date for example), `+e.start || ''` is `NaN || ''` which is `''`. The computed finger print thus ignores both start and end. 
This commit fixes the issue by checking if start/end is a valid moment object. If it is not, it tries to build a moment object. `moment().unix()` returns the number of milliseconds since unix epoch.

This commit might have a performance impact.