### PR TITLE
update calendar settings keep the current view name and start date

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -244,6 +244,7 @@ angular.module('ui.calendar', [])
 
         scope.destroy = function(){
           if(calendar && calendar.fullCalendar){
+            scope.lastView = calendar.fullCalendar('getView');
             calendar.fullCalendar('destroy');
           }
           if(attrs.calendar) {
@@ -257,7 +258,12 @@ angular.module('ui.calendar', [])
           calendar.fullCalendar(options);
           if(attrs.calendar) {
             uiCalendarConfig.calendars[attrs.calendar] = calendar;
-          }          
+          }
+          if(scope.lastView) {
+            calendar.fullCalendar('changeView', scope.lastView.name);
+            calendar.fullCalendar('gotoDate', scope.lastView.start);
+            scope.lastView = undefined;
+          }
         };
 
         eventSourcesWatcher.onAdded = function(source) {


### PR DESCRIPTION
Hi,

I'm using this calendar, and I'm suffering from the destroy&& init which doesn't keep the current date and view name.

You will find a patch here which fix this behavior
according to a answer on stack: http://stackoverflow.com/a/18047251