### PR TITLE
Update to fullcalendar v2.5.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "angular": "~1.4.1",
     "jquery": "~2.1.4",
-    "fullcalendar": "~2.3.2",
+    "fullcalendar": "~2.5.0",
     "moment": "~2.10.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "license": "MIT",
   "homepage": "http://angular-ui.github.com",
   "main": "src/calendar.js",
-  "dependencies": {},
+  "dependencies": {
+    "fullcalendar": "~2.5.0"
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-connect": "^0.10.1",


### PR DESCRIPTION
We've done some testing and with our usage of angular-ui-calendar there are no obvious errors in upgrading to fullcalendar 2.5.0. Also checked the changelog for anything that could potentially break and found nothing:

https://github.com/fullcalendar/fullcalendar/blob/3a464732a77eac8999875525549d19be0c423d5f/CHANGELOG.md

This fixes #350 and supersedes #352.