### PR TITLE
Update fullcalendar to 2.6.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "angular": "~1.4.1",
     "jquery": "~2.1.4",
-    "fullcalendar": "~2.3.2",
+    "fullcalendar": "~2.6.0",
     "moment": "~2.10.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes issue where `customButtons` is not appearing the calendar

As mentioned in https://github.com/angular-ui/ui-calendar/issues/328

