### PR TITLE
Register calendar before initialize

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -262,10 +262,10 @@ angular.module('ui.calendar', [])
           if (!calendar) {
             calendar = angular.element(elm).html('');
           }
-          calendar.fullCalendar(options);
           if(attrs.calendar) {
             uiCalendarConfig.calendars[attrs.calendar] = calendar;
           }          
+          calendar.fullCalendar(options);
         };
         scope.$on('$destroy', function() {
           scope.destroyCalendar();


### PR DESCRIPTION
Client code can define hooks for fullCalendar in the options that can be called during initialization.  For example if a caller specifies "viewRender" and inside viewRender they would like to access the calendar object, this isn't possible since the uiCalendarConfig is not yet configured.  By adding the new calendar to uiCalendarConfig before calling fullCalendar(options) it allows clients to define these functions.