### PR TITLE
Fixed handling of the calendar-watch-event attribute

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -15,7 +15,7 @@ angular.module('ui.calendar', [])
       var sourceSerialId = 1,
           eventSerialId = 1,
           sources = $scope.eventSources,
-          extraEventSignature = $scope.calendarWatchEvent ? $scope.calendarWatchEvent : angular.noop,
+          extraEventSignature = $scope.calendarWatchEvent() ? $scope.calendarWatchEvent() : angular.noop,
 
           wrapFunctionWithScopeApply = function(functionToWrap){
               var wrapper;


### PR DESCRIPTION
I'm not able to test this easily, but at least for my version of AngularJS (which is ancient), the $scope.calendarWatchEvent property is a function that fetches the actual function from the scope. Therefore, its needs to be run instead of just accepting it as it is.

Please disregard if I'm wrong or if this is no longer relevant for more recent versions of AngularJS :)
