### PR TITLE
Edit initCalendar to work properly with jQuery

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -281,7 +281,7 @@ angular.module('ui.calendar', [])
 
                     scope.initCalendar = function () {
                         if (!calendar) {
-                            calendar = angular.element(elm).html('');
+                            calendar = $(elm).html('');
                         }
                         calendar.fullCalendar(options);
                         if (attrs.calendar) {


### PR DESCRIPTION
Resolve #267 "calendar.fullCalendar is not a function" This is simply the change mentioned in the comments on that issue. I haven't seen anything stating that this breaks the build for others or has a negative consequence, so I think this would be a good change to fix it so others do not have this issue going forward.