### PR TITLE
patch bower.json to use same moment dependency as fullcalendar

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "angular": "~1.4.x",
     "jquery": "~2.1.4",
     "fullcalendar": "~2.7.1",
-    "moment": "~2.10.3"
+    "moment": ">=2.5.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.x",


### PR DESCRIPTION
Change moment version to be the same as required by full calendar ( >= 2.5.0 ), this way people can decide which version of moment to run 