### PR TITLE
Declare a calendar name in the demo example code

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -178,7 +178,7 @@
             </div>
             <h3>How?</h3>
         <pre class="prettyprint linenums">
-&lt;div ui-calendar="{{uiConfig.calendar}}" class="span8 calendar" ng-model="eventSources"&gt;&lt;/div&gt; 
+&lt;div ui-calendar="{{uiConfig.calendar}}" calendar="myCalendar" class="span8 calendar" ng-model="eventSources"&gt;&lt;/div&gt; 
 
 /**
  * calendarDemoApp - 0.9.0


### PR DESCRIPTION
Any functions that need to access the calendar object, such as the "renderCalender" function, will not work out of the box because no name has been declared for the calendar. Adding the calendar attribute in the demo example will make it easier to get started quickly.