### PR TITLE
allows calendar to use latest version of angular 1.X.X

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "package.json"
   ],
   "dependencies": {
-    "angular": "~1.4.x",
+    "angular": ">=1.4.x",
     "jquery": "~2.1.4",
     "fullcalendar": "~2.7.1",
     "moment": ">=2.5.0"
@@ -27,6 +27,6 @@
   },
   "resolutions": {
     "jquery": "~2.1.4",
-    "angular": "~1.4.x"
+    "angular": ">=1.4.x"
   }
 }


### PR DESCRIPTION
+ Made change to bower file to allow greater versions than 1.4.X 
+ Upgraded to Angular 1.5.8 
+ Tested using grunt serve , everything seemed to be working 
+ Ran unit tests and passed 

This will allow developers to use this library with Angular version 1.4.X and above 