### PR TITLE
Support for jQuery v3.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,16 +17,16 @@
   ],
   "dependencies": {
     "angular": ">=1.4.x",
-    "jquery": "~2.1.4",
-    "fullcalendar": "~2.7.1",
-    "moment": ">=2.5.0"
+    "jquery": "~3.1.1",
+    "fullcalendar": "~2.9.1",
+    "moment": ">=2.9.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.x",
     "bootstrap-css": "2.3.1"
   },
   "resolutions": {
-    "jquery": "~2.1.4",
+    "jquery": "^3.1.1",
     "angular": ">=1.4.x"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "angular": ">=1.4.x",
     "jquery": "~3.1.1",
     "fullcalendar": "~2.9.1",
-    "moment": ">=2.9.0"
+    "moment": ">=2.5.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.x",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "http://angular-ui.github.com",
   "main": "src/calendar.js",
   "dependencies": {
-    "fullcalendar": "~2.7.1"
+    "fullcalendar": "~2.9.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Closes https://github.com/angular-ui/ui-calendar/issues/450

---

Updates FullCalendar dependency to [v2.9.1](https://github.com/fullcalendar/fullcalendar/releases/tag/v2.9.1), which includes support for jQuery v3.0. ~~Also bumps version for Moment in anticipation of eventual support for FullCalendar v3.x, where [Moment v2.9 is minimum version required](https://github.com/fullcalendar/fullcalendar/releases/tag/v3.0.0).~~

**References:**

- https://github.com/fullcalendar/fullcalendar/issues/3124
- https://github.com/fullcalendar/fullcalendar/releases/tag/v2.9.1