### PR TITLE
Fixed "reduce is not a function" errors.

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -70,7 +70,7 @@ angular.module('ui.calendar', [])
             this.allEvents = function () {
                 return Array.prototype.concat.apply(
                     [],
-                    (sources || []).reduce(
+                    (Array.from(sources) || []).reduce(
                         function (previous, source) {
                             if (angular.isArray(source)) {
                                 previous.push(source);
@@ -108,7 +108,7 @@ angular.module('ui.calendar', [])
                 var self;
 
                 var getTokens = function () {
-                    return ((angular.isFunction(arraySource) ? arraySource() : arraySource) || []).reduce(
+                    return (Array.from(angular.isFunction(arraySource) ? arraySource() : arraySource) || []).reduce(
                         function (rslt, el) {
                             var token = tokenFn(el);
                             map[token] = el;

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -16,7 +16,7 @@ angular.module('ui.calendar', [])
     .controller('uiCalendarCtrl', ['$scope', '$locale',
         function ($scope, $locale) {
 
-            var sources = $scope.eventSources;
+            var sources = typeof ($scope.eventSources) !== "undefined" && $scope.eventSources !== null ? $scope.eventSources : [];
             var extraEventSignature = $scope.calendarWatchEvent ? $scope.calendarWatchEvent : angular.noop;
 
             var wrapFunctionWithScopeApply = function (functionToWrap) {
@@ -240,7 +240,7 @@ angular.module('ui.calendar', [])
                 },
                 controller : 'uiCalendarCtrl',
                 link : function (scope, elm, attrs, controller) {
-                    var sources = scope.eventSources;
+                    var sources = typeof (scope.eventSources) !== "undefined" && scope.eventSources !== null ? scope.eventSources : [];
                     var sourcesChanged = false;
                     var calendar;
                     var eventSourcesWatcher = controller.changeWatcher(sources, controller.sourceFingerprint);
@@ -362,4 +362,4 @@ angular.module('ui.calendar', [])
             };
         }
     ]
-);
+    );


### PR DESCRIPTION
I was getting these errors on Chrome when loading events onto a calendar. The fix is not compatible with Internet Explorer but can be polyfilled according to [this MDN page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#Polyfill)