### PR TITLE
Make upgrading angular compatible with tools that use higher versions…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "package.json"
   ],
   "dependencies": {
-    "angular": ">=1.4.x",
+    "angular": ">=1.4",
     "jquery": "~3.1.1",
     "fullcalendar": "~2.9.1",
     "moment": ">=2.5.0"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ampion-angular-ui-calendar",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "A complete AngularJS directive for the Arshaw FullCalendar.",
   "author": "https://github.com/angular-ui/ui-calendar/graphs/contributors",
   "license": "MIT",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ampion-angular-ui-calendar",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A complete AngularJS directive for the Arshaw FullCalendar.",
   "author": "https://github.com/angular-ui/ui-calendar/graphs/contributors",
   "license": "MIT",

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-ui-calendar",
+  "name": "ampion-angular-ui-calendar",
   "version": "1.0.2",
   "description": "A complete AngularJS directive for the Arshaw FullCalendar.",
   "author": "https://github.com/angular-ui/ui-calendar/graphs/contributors",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ampion-angular-ui-calendar",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A complete AngularJS directive for the Arshaw FullCalendar.",
   "author": "https://github.com/angular-ui/ui-calendar/graphs/contributors",
   "license": "MIT",
@@ -27,6 +27,6 @@
   },
   "resolutions": {
     "jquery": "^3.1.1",
-    "angular": ">=1.4.x"
+    "angular": ">=1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ampion-angular-ui-calendar",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A complete AngularJS directive for the Arshaw FullCalendar.",
   "author": "https://github.com/angular-ui/ui-calendar/graphs/contributors",
   "license": "MIT",
@@ -30,6 +30,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/angular-ui/ui-calendar.git"
+    "url": "git://github.com/AcadiaMicro/ui-calendar.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-ui-calendar",
+  "name": "ampion-angular-ui-calendar",
   "version": "1.0.2",
   "description": "A complete AngularJS directive for the Arshaw FullCalendar.",
   "author": "https://github.com/angular-ui/ui-calendar/graphs/contributors",


### PR DESCRIPTION
… of semver, while still maintaining backwards compatibility with older versions of semver

The current syntax of including the ".x" unnecessarily causes issues with systems using newer versions of semver for example: https://github.com/tenex/rails-assets/issues/405 (please excuse the self reference)

I'm open to feedback of course.