### PR TITLE
get eventSources from scope in getOptions method

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -252,6 +252,10 @@ angular.module('ui.calendar', [])
                         var fullCalendarConfig = controller.getFullCalendarConfig(calendarSettings, uiCalendarConfig);
                         var localeFullCalendarConfig = controller.getLocaleConfig(fullCalendarConfig);
                         angular.extend(localeFullCalendarConfig, fullCalendarConfig);
+                        
+                        //pull sources into options each time getOptions() is called.
+                        sources = scope.eventSources;
+                        
                         options = {
                             eventSources : sources
                         };


### PR DESCRIPTION
Allows for flexible assignment of eventSource within an Angular service or directive.